### PR TITLE
+ fix condition_operator id so field can be checked still (safer)

### DIFF
--- a/customerautogroups/controllers/admin/rules.php
+++ b/customerautogroups/controllers/admin/rules.php
@@ -159,12 +159,12 @@ class RulesController extends ModuleAdminController
 
         //Liste des opérateurs
         $operatorsList = array(
-            array('id' => '=', 'value' => '='),
-            array('id' => '!=', 'value' => '!='),
-            array('id' => '>', 'value' => '>'),
-            array('id' => '>=', 'value' => '>='),
-            array('id' => '<', 'value' => '<'),
-            array('id' => '<=', 'value' => '<='),
+            array('id' => 'eq', 'value' => '='),
+            array('id' => 'ne', 'value' => '!='),
+            array('id' => 'gt', 'value' => '>'),
+            array('id' => 'ge', 'value' => '>='),
+            array('id' => 'lt', 'value' => '<'),
+            array('id' => 'le', 'value' => '<='),
             array('id' => 'LIKE %', 'value' => 'LIKE %'),
         );
 

--- a/customerautogroups/customerautogroups.php
+++ b/customerautogroups/customerautogroups.php
@@ -192,27 +192,27 @@ class customerautogroups extends Module
 
             switch ($rule['condition_operator']) {
 
-                case '=':
+                case 'eq':
                     if ($obj->{$rule['condition_field']} == $rule['condition_value']) $ruleApplied = true;
                     break;
 
-                case '!=':
+                case 'ne':
                     if ($obj->{$rule['condition_field']} != $rule['condition_value']) $ruleApplied = true;
                     break;
 
-                case '>':
+                case 'gt':
                     if ($obj->{$rule['condition_field']} > $rule['condition_value']) $ruleApplied = true;
                     break;
 
-                case '>=':
+                case 'ge':
                     if ($obj->{$rule['condition_field']} >= $rule['condition_value']) $ruleApplied = true;
                     break;
 
-                case '<':
+                case 'lt':
                     if ($obj->{$rule['condition_field']} < $rule['condition_value']) $ruleApplied = true;
                     break;
 
-                case '<=':
+                case 'le':
                     if ($obj->{$rule['condition_field']} <= $rule['condition_value']) $ruleApplied = true;
                     break;
 


### PR DESCRIPTION
I know you have fixed it already by removing the isCleanHTML check from AutoGroupRule.php but i think it is safer to keep that check on. By simply changing the id of the operator list you can keep it

Well you'll do as you wish, I just push my pull request forward ;)

Many thanks for your work and for your module.

Cheers!
